### PR TITLE
Add a hacky fix so pyrseas works with postgres 13

### DIFF
--- a/pyrseas/database.py
+++ b/pyrseas/database.py
@@ -521,8 +521,11 @@ class Database(object):
         if quote_reserved:
             fetch_reserved_words(self.dbconn)
 
-        langs = [lang[0] for lang in self.dbconn.fetchall(
-            "SELECT tmplname FROM pg_pltemplate")]
+        if self.dbconn.version < 130000:
+            langs = [lang[0] for lang in self.dbconn.fetchall(
+                "SELECT tmplname FROM pg_pltemplate")]
+        else:
+            langs = ['plpgsql', 'pltcl', 'pltclu', 'plperl', 'plperlu', 'plpythonu', 'plpython2u', 'plpython3u']
         self.from_map(input_map, langs)
         if opts.revert:
             (self.db, self.ndb) = (self.ndb, self.db)


### PR DESCRIPTION
Pyrseas used the pg_pltemplate table to know which extensions were
languages. This catalog table was removed in postgres13. To stop
pyrseas from crashing during yamltodb, we can just hardcode the result
of query it was doing. This is hacky but fine for a few reasons.

- Adding / removing language extensions is rare, don't think we've
  ever done it at Wave. Not sure why we'd want something besides
  plpgsql and plpython3u
- When it fails, it will fail loudly. E.g. somewhere in the code it
  will look 'plpgr' and find no entry